### PR TITLE
local deployment config

### DIFF
--- a/.local/README.md
+++ b/.local/README.md
@@ -1,0 +1,1 @@
+The `.local` folder contains copies of all files, adapted to run on localhost.

--- a/.local/README.md
+++ b/.local/README.md
@@ -1,1 +1,36 @@
+# Local deployment of the FAIR Data Station/Train
+
 The `.local` folder contains copies of all files, adapted to run on localhost.
+
+## How to run
+
+Run as follows (from `.local` dir):
+
+```bash
+docker compose up -d
+```
+
+## Manual configuration of keycloak
+
+Note that it is possible to disable keycloak by setting `NUXT_PUBLIC_KEYCLOAK_DISABLED: false` in the compose file.
+
+However, in order to test the full configuration, keycloak should be enabled (default).
+
+To configure keycloak, follow these steps, making sure the values match those defined in the compose file:
+
+1. use a web browser to open the admin console at https://localhost:8085
+2. log in using the dummy admin credentials defined in the `compose.yml` file
+3. create a realm with *Name* `fdt` (matching `NUXT_PUBLIC_KEYCLOAK_REALM`)
+4. in this realm, under "Clients", create a client with *Client ID* `trainhandler-client` (matching `NUXT_PUBLIC_KEYCLOAK_CLIENT_ID`)
+5. after saving the client, edit again to set both *Valid redirect URIs* and *Valid post logout redirect URIs* to `http://localhost:3000/*`
+6. under "Realm roles" create a new role with name `user` (expected by trainhandler-server)
+7. under "Groups" create a new group with name `users` (arbitrary)
+8. select the `users` group, select the *Role mapping* tab, and assign the `user` role
+9. under "Users", create a new user with *Username* `test` (arbitrary)
+10. select the user's *Credentials* tab, and set a password
+11. select the user's *Groups* tab, and join the `users` group
+
+Now we can visit http://localhost:3000 and log in using the `test` user.
+
+TODO: Something is not quite right yet, because the train handler keeps refreshing at an approximate two second interval.
+Maybe a redirect loop of some kind? 

--- a/.local/README.md
+++ b/.local/README.md
@@ -24,11 +24,9 @@ To configure keycloak, follow these steps, making sure the values match those de
 4. in this realm, under "Clients", create a client with *Client ID* `trainhandler-client` (matching `NUXT_PUBLIC_KEYCLOAK_CLIENT_ID`)
 5. after saving the client, edit again to set both *Valid redirect URIs* and *Valid post logout redirect URIs* to `http://localhost:3000/*`
 6. under "Realm roles" create a new role with name `user` (expected by trainhandler-server)
-7. under "Groups" create a new group with name `users` (arbitrary)
-8. select the `users` group, select the *Role mapping* tab, and assign the `user` role
-9. under "Users", create a new user with *Username* `test` (arbitrary)
-10. select the user's *Credentials* tab, and set a password
-11. select the user's *Groups* tab, and join the `users` group
+7. under "Users", create a new user with *Username* `test` (arbitrary)
+8. select the user's *Credentials* tab and set a password (disable "Temporary", for convenience)
+9. select the user's *Role mapping* tab and assign the `user` role
 
 Now we can visit http://localhost:3000 and log in using the `test` user.
 

--- a/.local/README.md
+++ b/.local/README.md
@@ -16,13 +16,13 @@ Note that it is possible to disable keycloak by setting `NUXT_PUBLIC_KEYCLOAK_DI
 
 However, in order to test the full configuration, keycloak should be enabled (default).
 
-To configure keycloak, follow these steps, making sure the values match those defined in the compose file:
+To [configure keycloak] manually, follow these steps, making sure the values match those defined in the compose file:
 
 1. use a web browser to open the admin console at https://localhost:8085
 2. log in using the dummy admin credentials defined in the `compose.yml` file
 3. create a realm with *Name* `fdt` (matching `NUXT_PUBLIC_KEYCLOAK_REALM`)
 4. in this realm, under "Clients", create a client with *Client ID* `trainhandler-client` (matching `NUXT_PUBLIC_KEYCLOAK_CLIENT_ID`)
-5. after saving the client, edit again to set both *Valid redirect URIs* and *Valid post logout redirect URIs* to `http://localhost:3000/*`
+5. set both *Valid redirect URIs* and *Valid post logout redirect URIs* for the client to `http://localhost:3000/*`, and save changes
 6. under "Realm roles" create a new role with name `user` (expected by trainhandler-server)
 7. under "Users", create a new user with *Username* `test` (arbitrary)
 8. select the user's *Credentials* tab and set a password (disable "Temporary", for convenience)
@@ -32,3 +32,5 @@ Now we can visit http://localhost:3000 and log in using the `test` user.
 
 TODO: Something is not quite right yet, because the train handler keeps refreshing at an approximate two second interval.
 Maybe a redirect loop of some kind? 
+
+[configure keycloak]: https://www.keycloak.org/docs/latest/authorization_services/index.html#_resource_server_overview

--- a/.local/README.md
+++ b/.local/README.md
@@ -10,10 +10,12 @@ Run as follows (from `.local` dir):
 docker compose up -d
 ```
 
-The keycloak server is configured automatically based on `realm.json`.
+The keycloak server is configured automatically based on `realm.json` (also see [keycloak examples] and [api spec]).
 
 Now we can visit http://localhost:3000 and log in using the `test` user (username: `test`, password: `test`).
 
+Note that keycloak may take some time to initialize, so in case of errors, check if it is ready.
+A docker compose healthcheck would be convenient here, but that is slightly complicated by [restrictions] in the default keycloak image.
 
 ## Manual configuration of keycloak
 
@@ -34,3 +36,6 @@ Do make sure the values match those defined in the compose file.
 Note that it is also possible to disable keycloak by setting `NUXT_PUBLIC_KEYCLOAK_DISABLED: false` in the compose file.
 
 [configure keycloak]: https://www.keycloak.org/docs/latest/authorization_services/index.html#_resource_server_overview
+[restrictions]: https://www.keycloak.org/server/health#_healthcheck
+[keycloak examples]: https://github.com/keycloak/keycloak-quickstarts/tree/latest/spring/rest-authz-resource-server
+[api spec]: https://www.keycloak.org/docs-api/26.0.8/rest-api//index.html#models

--- a/.local/README.md
+++ b/.local/README.md
@@ -10,13 +10,15 @@ Run as follows (from `.local` dir):
 docker compose up -d
 ```
 
+The keycloak server is configured automatically based on `realm.json`.
+
+Now we can visit http://localhost:3000 and log in using the `test` user (username: `test`, password: `test`).
+
+
 ## Manual configuration of keycloak
 
-Note that it is possible to disable keycloak by setting `NUXT_PUBLIC_KEYCLOAK_DISABLED: false` in the compose file.
-
-However, in order to test the full configuration, keycloak should be enabled (default).
-
-To [configure keycloak] manually, follow these steps, making sure the values match those defined in the compose file:
+If necessary, it is also possible to [configure keycloak] manually, following the steps below.
+Do make sure the values match those defined in the compose file.
 
 1. use a web browser to open the admin console at https://localhost:8085
 2. log in using the dummy admin credentials defined in the `compose.yml` file
@@ -28,9 +30,7 @@ To [configure keycloak] manually, follow these steps, making sure the values mat
 8. select the user's *Credentials* tab and set a password (disable "Temporary", for convenience)
 9. select the user's *Role mapping* tab and assign the `user` role
 
-Now we can visit http://localhost:3000 and log in using the `test` user.
 
-TODO: Something is not quite right yet, because the train handler keeps refreshing at an approximate two second interval.
-Maybe a redirect loop of some kind? 
+Note that it is also possible to disable keycloak by setting `NUXT_PUBLIC_KEYCLOAK_DISABLED: false` in the compose file.
 
 [configure keycloak]: https://www.keycloak.org/docs/latest/authorization_services/index.html#_resource_server_overview

--- a/.local/compose.yml
+++ b/.local/compose.yml
@@ -26,6 +26,9 @@ services:
         condition: service_healthy
     volumes:
       - ./trainhandler.application.yml:/app/application.yml:ro
+    environment:
+      # use TRACE if log messages are truncated
+      LOGGING_LEVEL_ORG_SPRINGFRAMEWORK_WEB: DEBUG
 
   fds:
     image: fairdata/fairdatastation:develop
@@ -39,6 +42,8 @@ services:
         condition: service_healthy
     volumes:
       - ./fds.application.yml:/app/application.yml:ro
+    environment:
+      LOGGING_LEVEL_ORG_SPRINGFRAMEWORK_WEB: DEBUG
 
   keycloak:
     # https://www.keycloak.org/getting-started/getting-started-docker

--- a/.local/compose.yml
+++ b/.local/compose.yml
@@ -37,7 +37,8 @@ services:
 
   keycloak:
     # https://www.keycloak.org/getting-started/getting-started-docker
-    image: quay.io/keycloak/keycloak:26.0
+    # todo: latest image is keycloak 26, but 25 and 26 cause a redirect loop, for some reason...
+    image: quay.io/keycloak/keycloak:24.0
     # beware: do not use `start-dev` in production (use `start` instead)
     command:
       - start-dev
@@ -58,7 +59,8 @@ services:
       KC_DB_URL_PORT: 5432
       KC_DB_USERNAME: postgres
       KC_DB_PASSWORD: password
-      KC_HOSTNAME: http://localhost:8085
+      # todo: for keycloak 25 and up, KC_HOSTNAME should be http://localhost:8085
+      KC_HOSTNAME: localhost:8085
       PROXY_ADDRESS_FORWARDING: true
       KC_PROXY: edge
       KC_HTTP_ENABLED: true

--- a/.local/compose.yml
+++ b/.local/compose.yml
@@ -1,12 +1,11 @@
-version: '3'
-
+name: fds-local
 services:
-
   trainhandler-client:
     image: fairdata/trainhandler-client:develop
     restart: unless-stopped
     ports:
-      - 127.0.0.1:3000:3000
+      # bound to 127.0.0.1 (localhost) to prevent exposing to public internet
+      - "127.0.0.1:3000:3000"
     environment:
       NUXT_PUBLIC_API_URL: http://localhost:8080
       NUXT_PUBLIC_KEYCLOAK_URL: http://localhost:8085
@@ -18,7 +17,7 @@ services:
     image: fairdata/trainhandler-server:develop
     restart: unless-stopped
     ports:
-      - 127.0.0.1:8080:8080
+      - "127.0.0.1:8080:8080"
     depends_on:
       - postgres
     volumes:
@@ -28,7 +27,7 @@ services:
     image: fairdata/fairdatastation:develop
     restart: unless-stopped
     ports:
-      - 127.0.0.1:8081:8080
+      - "127.0.0.1:8081:8080"
     depends_on:
       - postgres
     volumes:
@@ -38,7 +37,7 @@ services:
     image: quay.io/keycloak/keycloak:19.0.3
     command: start
     ports:
-      - 127.0.0.1:8085:8085
+      - "127.0.0.1:8085:8085"
     depends_on:
       - postgres
     environment:
@@ -63,11 +62,14 @@ services:
   postgres:
     image: postgres:15.1
     ports:
-      - 127.0.0.1:15432:5432
+      - "127.0.0.1:54321:5432"
     volumes:
-      - ./postgres/init.sql:/docker-entrypoint-initdb.d/00-init.sql
-      - ./postgres/data:/var/lib/postgresql/data
+      - ./init.sql:/docker-entrypoint-initdb.d/00-init.sql
+      - postgresdata:/var/lib/postgresql/data
     environment:
       POSTGRES_DB: postgres
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password
+
+volumes:
+  postgresdata:

--- a/.local/compose.yml
+++ b/.local/compose.yml
@@ -19,7 +19,8 @@ services:
     ports:
       - "127.0.0.1:8080:8080"
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
     volumes:
       - ./trainhandler.application.yml:/app/application.yml:ro
 
@@ -29,7 +30,8 @@ services:
     ports:
       - "127.0.0.1:8081:8080"
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
     volumes:
       - ./fds.application.yml:/app/application.yml:ro
 
@@ -39,7 +41,8 @@ services:
     ports:
       - "127.0.0.1:8085:8085"
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
     environment:
       KEYCLOAK_ADMIN: admin
       KEYCLOAK_ADMIN_PASSWORD: admin
@@ -70,6 +73,9 @@ services:
       POSTGRES_DB: postgres
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password
+    healthcheck:
+      # https://www.postgresql.org/docs/current/app-pg-isready.html
+      test: pg_isready --dbname=postgres || exit 1
 
 volumes:
   postgresdata:

--- a/.local/compose.yml
+++ b/.local/compose.yml
@@ -2,7 +2,6 @@ name: fds-local
 services:
   trainhandler-client:
     image: fairdata/trainhandler-client:develop
-    restart: unless-stopped
     ports:
       # bound to 127.0.0.1 (localhost) to prevent exposing to public internet
       - "127.0.0.1:3000:3000"
@@ -17,7 +16,6 @@ services:
 
   trainhandler-server:
     image: fairdata/trainhandler-server:develop
-    restart: unless-stopped
     ports:
       - "127.0.0.1:8080:8080"
     depends_on:
@@ -31,8 +29,10 @@ services:
 
   fds:
     image: fairdata/fairdatastation:develop
-    restart: unless-stopped
+    # the trainhandler client requires hostname with dot and top level domain (station uri field hostname with container port)
+    hostname: fds.local
     ports:
+      # <host>:<container>
       - "127.0.0.1:8081:8080"
     depends_on:
       postgres:
@@ -90,6 +90,8 @@ services:
     healthcheck:
       # https://www.postgresql.org/docs/current/app-pg-isready.html
       test: pg_isready --dbname=postgres || exit 1
+      start_period: 30s
+      start_interval: 3s
 
 volumes:
   pgdata:

--- a/.local/compose.yml
+++ b/.local/compose.yml
@@ -8,7 +8,7 @@ services:
     depends_on:
       - trainhandler-server
     environment:
-      NUXT_PUBLIC_API_URL: http://localhost:8080
+      NUXT_PUBLIC_API_URL: http://localhost:8082
       NUXT_PUBLIC_KEYCLOAK_URL: http://localhost:8085
       NUXT_PUBLIC_KEYCLOAK_REALM: fdt
       NUXT_PUBLIC_KEYCLOAK_CLIENT_ID: trainhandler-client
@@ -17,7 +17,7 @@ services:
   trainhandler-server:
     image: fairdata/trainhandler-server:develop
     ports:
-      - "127.0.0.1:8080:8080"
+      - "127.0.0.1:8082:8080"
     depends_on:
       keycloak:
         # service_healthy would be preferable, but is complicated because default keycloak image has no curl

--- a/.local/compose.yml
+++ b/.local/compose.yml
@@ -1,0 +1,73 @@
+version: '3'
+
+services:
+
+  trainhandler-client:
+    image: fairdata/trainhandler-client:develop
+    restart: unless-stopped
+    ports:
+      - 127.0.0.1:3000:3000
+    environment:
+      NUXT_PUBLIC_API_URL: https://api.handler.fairdatatrain.org
+      NUXT_PUBLIC_KEYCLOAK_URL: https://auth.fairdatatrain.org
+      NUXT_PUBLIC_KEYCLOAK_REALM: fdt
+      NUXT_PUBLIC_KEYCLOAK_CLIENT_ID: trainhandler-client
+     # NUXT_PUBLIC_KEYCLOAK_DISABLED: true
+
+  trainhandler-server:
+    image: fairdata/trainhandler-server:develop
+    restart: unless-stopped
+    ports:
+      - 127.0.0.1:8080:8080
+    depends_on:
+      - postgres
+    volumes:
+      - ./trainhandler/application.yml:/app/application.yml:ro
+
+  fds:
+    image: fairdata/fairdatastation:develop
+    restart: unless-stopped
+    ports:
+      - 127.0.0.1:8081:8080
+    depends_on:
+      - postgres
+    volumes:
+      - ./fds/application.yml:/app/application.yml:ro
+
+  keycloak:
+    image: quay.io/keycloak/keycloak:19.0.3
+    command: start
+    ports:
+      - 127.0.0.1:8085:8085
+    depends_on:
+      - postgres
+    environment:
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+      #KC_DB_URL: jdbc:postgresql://postgres/keycloak
+      KC_DB: postgres
+      KC_DB_SCHEMA: public
+      KC_DB_URL_DATABASE: keycloak
+      KC_DB_URL_HOST: postgres
+      KC_DB_URL_PORT: 5432
+      KC_DB_USERNAME: postgres
+      KC_DB_PASSWORD: password
+      KC_HOSTNAME: auth.fairdatatrain.org
+      PROXY_ADDRESS_FORWARDING: true
+      KC_PROXY: edge
+      KC_HTTP_ENABLED: true
+      KC_HTTP_PORT: 8085
+      KC_HOSTNAME_STRICT_HTTPS: false
+      KC_HOSTNAME_STRICT: false
+
+  postgres:
+    image: postgres:15.1
+    ports:
+      - 127.0.0.1:15432:5432
+    volumes:
+      - ./postgres/init.sql:/docker-entrypoint-initdb.d/00-init.sql
+      - ./postgres/data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_DB: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password

--- a/.local/compose.yml
+++ b/.local/compose.yml
@@ -49,9 +49,11 @@ services:
       postgres:
         condition: service_healthy
     environment:
-      KC_BOOTSTRAP_ADMIN_USERNAME: admin
-      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
-      #KC_DB_URL: jdbc:postgresql://postgres/keycloak
+      # todo: for keycloak 25 and up, use the following, instead of KEYCLOAK_ADMIN*:
+      #  KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      #  KC_BOOTSTRAP_ADMIN_PASSWORD: admin
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
       KC_DB: postgres
       KC_DB_SCHEMA: public
       KC_DB_URL_DATABASE: keycloak

--- a/.local/compose.yml
+++ b/.local/compose.yml
@@ -94,7 +94,7 @@ services:
       POSTGRES_PASSWORD: password
     healthcheck:
       # https://www.postgresql.org/docs/current/app-pg-isready.html
-      test: pg_isready --dbname=postgres || exit 1
+      test: pg_isready --dbname=postgres --username=postgres || exit 1
       start_period: 30s
       start_interval: 3s
 

--- a/.local/compose.yml
+++ b/.local/compose.yml
@@ -37,7 +37,9 @@ services:
 
   keycloak:
     image: quay.io/keycloak/keycloak:19.0.3
-    command: start
+    command:
+      - start
+      - --import-realm
     ports:
       - "127.0.0.1:8085:8085"
     depends_on:
@@ -61,6 +63,8 @@ services:
       KC_HTTP_PORT: 8085
       KC_HOSTNAME_STRICT_HTTPS: false
       KC_HOSTNAME_STRICT: false
+    volumes:
+      - ./realm.json:/opt/keycloak/data/import/realm.json:ro
 
   postgres:
     image: postgres:15.1

--- a/.local/compose.yml
+++ b/.local/compose.yml
@@ -68,8 +68,7 @@ services:
       KC_DB_PASSWORD: password
       # todo: for keycloak 25 and up, KC_HOSTNAME should be http://localhost:8085
       KC_HOSTNAME: localhost:8085
-      PROXY_ADDRESS_FORWARDING: true
-      KC_PROXY: edge
+      KC_PROXY_HEADERS: xforwarded  # or `forwarded|xforwarded`?
       KC_HTTP_ENABLED: true
       KC_HTTP_PORT: 8085
       KC_HOSTNAME_STRICT_HTTPS: false

--- a/.local/compose.yml
+++ b/.local/compose.yml
@@ -6,6 +6,8 @@ services:
     ports:
       # bound to 127.0.0.1 (localhost) to prevent exposing to public internet
       - "127.0.0.1:3000:3000"
+    depends_on:
+      - trainhandler-server
     environment:
       NUXT_PUBLIC_API_URL: http://localhost:8080
       NUXT_PUBLIC_KEYCLOAK_URL: http://localhost:8085
@@ -19,6 +21,9 @@ services:
     ports:
       - "127.0.0.1:8080:8080"
     depends_on:
+      keycloak:
+        # service_healthy would be preferable, but is complicated because default keycloak image has no curl
+        condition: service_started
       postgres:
         condition: service_healthy
     volumes:

--- a/.local/compose.yml
+++ b/.local/compose.yml
@@ -8,8 +8,8 @@ services:
     ports:
       - 127.0.0.1:3000:3000
     environment:
-      NUXT_PUBLIC_API_URL: https://api.handler.fairdatatrain.org
-      NUXT_PUBLIC_KEYCLOAK_URL: https://auth.fairdatatrain.org
+      NUXT_PUBLIC_API_URL: http://localhost:8080
+      NUXT_PUBLIC_KEYCLOAK_URL: http://localhost:8085
       NUXT_PUBLIC_KEYCLOAK_REALM: fdt
       NUXT_PUBLIC_KEYCLOAK_CLIENT_ID: trainhandler-client
      # NUXT_PUBLIC_KEYCLOAK_DISABLED: true
@@ -22,7 +22,7 @@ services:
     depends_on:
       - postgres
     volumes:
-      - ./trainhandler/application.yml:/app/application.yml:ro
+      - ./trainhandler.application.yml:/app/application.yml:ro
 
   fds:
     image: fairdata/fairdatastation:develop
@@ -32,7 +32,7 @@ services:
     depends_on:
       - postgres
     volumes:
-      - ./fds/application.yml:/app/application.yml:ro
+      - ./fds.application.yml:/app/application.yml:ro
 
   keycloak:
     image: quay.io/keycloak/keycloak:19.0.3
@@ -52,7 +52,7 @@ services:
       KC_DB_URL_PORT: 5432
       KC_DB_USERNAME: postgres
       KC_DB_PASSWORD: password
-      KC_HOSTNAME: auth.fairdatatrain.org
+      KC_HOSTNAME: localhost:8085
       PROXY_ADDRESS_FORWARDING: true
       KC_PROXY: edge
       KC_HTTP_ENABLED: true

--- a/.local/compose.yml
+++ b/.local/compose.yml
@@ -36,9 +36,11 @@ services:
       - ./fds.application.yml:/app/application.yml:ro
 
   keycloak:
-    image: quay.io/keycloak/keycloak:19.0.3
+    # https://www.keycloak.org/getting-started/getting-started-docker
+    image: quay.io/keycloak/keycloak:26.0
+    # beware: do not use `start-dev` in production (use `start` instead)
     command:
-      - start
+      - start-dev
       - --import-realm
     ports:
       - "127.0.0.1:8085:8085"
@@ -46,8 +48,8 @@ services:
       postgres:
         condition: service_healthy
     environment:
-      KEYCLOAK_ADMIN: admin
-      KEYCLOAK_ADMIN_PASSWORD: admin
+      KC_BOOTSTRAP_ADMIN_USERNAME: admin
+      KC_BOOTSTRAP_ADMIN_PASSWORD: admin
       #KC_DB_URL: jdbc:postgresql://postgres/keycloak
       KC_DB: postgres
       KC_DB_SCHEMA: public
@@ -56,7 +58,7 @@ services:
       KC_DB_URL_PORT: 5432
       KC_DB_USERNAME: postgres
       KC_DB_PASSWORD: password
-      KC_HOSTNAME: localhost:8085
+      KC_HOSTNAME: http://localhost:8085
       PROXY_ADDRESS_FORWARDING: true
       KC_PROXY: edge
       KC_HTTP_ENABLED: true
@@ -67,12 +69,12 @@ services:
       - ./realm.json:/opt/keycloak/data/import/realm.json:ro
 
   postgres:
-    image: postgres:15.1
+    image: postgres:17.2
     ports:
       - "127.0.0.1:54321:5432"
     volumes:
       - ./init.sql:/docker-entrypoint-initdb.d/00-init.sql
-      - postgresdata:/var/lib/postgresql/data
+      - pgdata:/var/lib/postgresql/data
     environment:
       POSTGRES_DB: postgres
       POSTGRES_USER: postgres
@@ -82,4 +84,4 @@ services:
       test: pg_isready --dbname=postgres || exit 1
 
 volumes:
-  postgresdata:
+  pgdata:

--- a/.local/data.sql
+++ b/.local/data.sql
@@ -1,0 +1,28 @@
+-- TRAINS
+INSERT INTO public.train_type (uuid, uri, title, note, created_at, updated_at)
+VALUES ('dfbee778-7a1a-4c8b-9ad8-946eed6d6884', 'https://w3id.org/fdp/fdt-o#SPARQLTrain', 'SPARQL Train', ' ', '2022-11-28 15:21:26.000000', '2022-11-28 15:21:26.000000');
+
+INSERT INTO public.train_garage (uuid, uri, display_name, note, metadata, last_contact_at, created_at, updated_at, status)
+VALUES ('46ce8916-19e1-4246-8515-a04d1f443709', 'https://trains.fairdatatrain.org/', 'Trains C4Yourself', '', null, '2022-11-28 15:04:50.000000', '2022-11-28 15:04:50.000000', '2022-11-28 15:04:50.000000', 'SYNCED');
+
+INSERT INTO public.train (uuid, uri, title, description, keywords, metadata, last_contact_at, train_garage_id, created_at, updated_at, status, soft_deleted)
+VALUES ('9957ef91-8f62-4f9b-a855-656589a24436', 'https://trains.fairdatatrain.org/train/cf4ca15b-f486-4e11-9434-f38f9770133e', 'SPARQL query to retrieve COVID 19 data', 'SPARQL query to retrieve COVID 19 cases per region in the Netherlands', null, null, '2022-11-28 15:23:46.000000', '46ce8916-19e1-4246-8515-a04d1f443709', '2022-11-28 15:23:46.000000', '2022-11-28 15:23:46.000000', 'SYNCED', false);
+INSERT INTO public.train_train_type (train_type_id, train_id)
+VALUES ('dfbee778-7a1a-4c8b-9ad8-946eed6d6884', '9957ef91-8f62-4f9b-a855-656589a24436');
+
+-- STATIONS (!! EDIT URI OF STATION)
+INSERT INTO public.station_directory (uuid, uri, display_name, note, metadata, last_contact_at, created_at, updated_at, status)
+VALUES ('e8ca259c-91b6-4e6b-963b-403b8f78bea7', 'http://example.com/station-directory', 'DEMO Station Directory', ' ', null, '2022-11-28 15:25:33.000000', '2022-11-28 15:25:33.000000', '2022-11-28 15:25:33.000000', 'SYNCED');
+
+INSERT INTO public.station (uuid, uri, title, description, keywords, metadata, last_contact_at, station_directory_id, created_at, updated_at, status, soft_deleted)
+VALUES ('1fe1506f-2f1d-45ad-9b48-e16fdb529654', 'https://fds.fairdatatrain.org', 'DEMO FDS', 'FAIR Data Station for demonstration purposes', null, null, '2022-11-28 15:26:01.000000', 'e8ca259c-91b6-4e6b-963b-403b8f78bea7', '2022-11-28 15:26:01.000000', '2022-11-28 15:26:01.000000', 'SYNCED', false);
+INSERT INTO public.station_train_type (train_type_id, station_id)
+VALUES ('dfbee778-7a1a-4c8b-9ad8-946eed6d6884', '1fe1506f-2f1d-45ad-9b48-e16fdb529654');
+
+-- PLAN
+INSERT INTO public.plan (uuid, display_name, note, train_id, created_at, updated_at)
+VALUES ('5a71f540-1019-47c2-98b7-a4c7db61746f', 'DEMO Plan', 'Plan for simple SPARQL train demonstration with just one station', '9957ef91-8f62-4f9b-a855-656589a24436', '2022-11-28 15:29:36.000000', '2022-11-28 15:29:36.000000');
+
+INSERT INTO public.plan_target (uuid, station_id, plan_id, created_at, updated_at)
+VALUES ('eba34fc4-d3b0-4f78-8986-5d04f359c5a4', '1fe1506f-2f1d-45ad-9b48-e16fdb529654', '5a71f540-1019-47c2-98b7-a4c7db61746f', '2022-11-28 15:29:36.000000', '2022-11-28 15:29:36.000000');
+

--- a/.local/fds.application.yml
+++ b/.local/fds.application.yml
@@ -1,0 +1,27 @@
+data-station:
+  # not needed now
+  fdp-url: http://fdp
+
+  # as in FDP
+  storages:
+    triple-store:
+      # valid repository type options {1 = inMemoryStore, 2 = NativeStore, 3 = AllegroGraph, 4 = graphDB, 5 = blazegraph}
+      type: 1
+      native:
+        dir: /tmp/fdp-store/
+      agraph:
+        url: http://localhost:10035/repositories/fdp
+        username: user
+        password: password
+      graphDb:
+        url: http://localhost:7200
+        repository: test
+      blazegraph:
+        url: http://localhost:8888/blazegraph
+        repository:
+
+spring:
+  datasource:
+    url: jdbc:postgresql://postgres/fds
+    username: postgres
+    password: password

--- a/.local/fds.application.yml
+++ b/.local/fds.application.yml
@@ -25,3 +25,9 @@ spring:
     url: jdbc:postgresql://postgres/fds
     username: postgres
     password: password
+
+logging:
+  level:
+    org:
+      springframework:
+        web: DEBUG

--- a/.local/fds.application.yml
+++ b/.local/fds.application.yml
@@ -26,8 +26,10 @@ spring:
     username: postgres
     password: password
 
+# NOTE we can also override this using an env variable, e.g.
+# LOGGING_LEVEL_ORG_SPRINGFRAMEWORK_WEB=TRACE
 logging:
   level:
     org:
       springframework:
-        web: DEBUG
+        web: INFO

--- a/.local/init.sql
+++ b/.local/init.sql
@@ -1,0 +1,3 @@
+CREATE DATABASE train_handler;
+CREATE DATABASE fds;
+CREATE DATABASE keycloak;

--- a/.local/realm.json
+++ b/.local/realm.json
@@ -4,6 +4,9 @@
   "users": [
     {
       "username": "test",
+      "email": "a.test@example.org",
+      "firstName": "a",
+      "lastName": "test",
       "enabled": true,
       "credentials": [
         {

--- a/.local/realm.json
+++ b/.local/realm.json
@@ -1,0 +1,45 @@
+{
+  "realm": "fdt",
+  "enabled": true,
+  "users": [
+    {
+      "username": "test",
+      "enabled": true,
+      "credentials": [
+        {
+          "type": "password",
+          "value": "test"
+        }
+      ],
+      "realmRoles": [
+        "user"
+      ]
+    }
+  ],
+  "roles": {
+    "realm": [
+      {
+        "name": "user"
+      }
+    ]
+  },
+  "clients": [
+    {
+      "clientId": "trainhandler-client",
+      "enabled": true,
+      "attributes": {
+        "post.logout.redirect.uris": "http://localhost:3000/*"
+      },
+      "redirectUris": [
+        "http://localhost:3000/*"
+      ],
+      "webOrigins": [
+        "http://localhost:3000"
+      ],
+      "authorizationServicesEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "standardFlowEnabled": true,
+      "publicClient": true
+    }
+  ]
+}

--- a/.local/trainhandler.application.yml
+++ b/.local/trainhandler.application.yml
@@ -16,7 +16,7 @@ spring:
     password: password
 
 keycloak:
-  enabled: true
+  enabled: false
   realm: fdt
   resource: trainhandler-api
   auth-server-url: http://keycloak:8085

--- a/.local/trainhandler.application.yml
+++ b/.local/trainhandler.application.yml
@@ -3,7 +3,7 @@ dispatcher:
     timeout: PT2M
   dispatch:
     # URL to root endpoint of TrainHandler API (for callbacks)
-    root: https://api.handler.fairdatatrain.org
+    root: http://localhost:8080
     # Can set to lower value for faster processing
     initDelay: PT30S
     interval: PT30S
@@ -18,6 +18,6 @@ keycloak:
   enabled: true
   realm: fdt
   resource: trainhandler-api
-  auth-server-url: https://auth.fairdatatrain.org
+  auth-server-url: http://keycloak:8085
   public-client: true
   bearer-only: true

--- a/.local/trainhandler.application.yml
+++ b/.local/trainhandler.application.yml
@@ -1,0 +1,23 @@
+dispatcher:
+  polling:
+    timeout: PT2M
+  dispatch:
+    # URL to root endpoint of TrainHandler API (for callbacks)
+    root: https://api.handler.fairdatatrain.org
+    # Can set to lower value for faster processing
+    initDelay: PT30S
+    interval: PT30S
+
+spring:
+  datasource:
+    url: jdbc:postgresql://postgres/train_handler
+    username: postgres
+    password: password
+
+keycloak:
+  enabled: true
+  realm: fdt
+  resource: trainhandler-api
+  auth-server-url: https://auth.fairdatatrain.org
+  public-client: true
+  bearer-only: true

--- a/.local/trainhandler.application.yml
+++ b/.local/trainhandler.application.yml
@@ -21,3 +21,9 @@ keycloak:
   auth-server-url: http://keycloak:8085
   public-client: true
   bearer-only: true
+
+logging:
+  level:
+    org:
+      springframework:
+        web: INFO

--- a/.local/trainhandler.application.yml
+++ b/.local/trainhandler.application.yml
@@ -2,8 +2,9 @@ dispatcher:
   polling:
     timeout: PT2M
   dispatch:
-    # URL to root endpoint of TrainHandler API (for callbacks)
-    root: http://localhost:8080
+    # URL to root endpoint of trainhandler-server
+    # (used to construct callback urls that fds then uses to POST event updates and artifacts)
+    root: http://trainhandler-server:8080
     # Can set to lower value for faster processing
     initDelay: PT30S
     interval: PT30S


### PR DESCRIPTION
example configuration for local deployment

- upgraded postgres image and keycloak image (up to 24, as 26 causes redirect loop)
- added postgres health check to prevent errors during initial deployment
- added keycloak realm configuration file, so manual setup is no longer required

just `docker compose up -d` and you can visit http://localhost:8085 (keycloak) and http://localhost:3000 (trainhandler-client), etc.

note that this has been reverse engineered, so I'm not entirely sure if everything is configured the way it should be

some notes:
- when creating a station using trainhandler-client, the URI (and endpoint?) should be `http://fds.local:8080/trains` (no trailing slash!)
- example trains can be found in [fds-demo-trains] (forked from [MarekSuchanek/fds-dummy-trains])
- when creating a train using the trainhandler-client ui, the URI can be e.g. `https://raw.githubusercontent.com/FAIRDataTeam/fds-demo-trains/refs/heads/main/trains/sparql/sparql-train-01.ttl` (also specify SPARQL train)

[MarekSuchanek/fds-dummy-trains]: https://github.com/MarekSuchanek/fds-dummy-trains
[fds-demo-trains]: https://github.com/FAIRDataTeam/fds-demo-trains